### PR TITLE
Run "test" workflow without startup errors.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,18 +10,16 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        symfony: [5.4.*, 6.3.*, 6.4.*, 7.0.*]
+        symfony: [5.4.*, 6.4.*, 7.2.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - php: "8.1"
             symfony: "^5.4"
           - php: "8.1"
-            symfony: "^6.3"
-          - php: "8.1"
             symfony: "^6.4"
         exclude:
           - php: "8.1"
-            symfony: "^7.0"
+            symfony: "^7.2"
 
     name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ubuntu-latest - ${{ matrix.dependency-version }}
     steps:
@@ -49,6 +47,7 @@ jobs:
           "symfony/dependency-injection:${{ matrix.symfony }}"
           "symfony/http-kernel:${{ matrix.symfony }}"
           --no-interaction --no-update
+
       - name: Install Composer dependencies
         run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
             symfony: 5.4.*
           - php: 8.4
             symfony: 6.4.*
+          - php: 8.4
+            symfony: 7.0.*
 
     name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ubuntu-latest - ${{ matrix.dependency-version }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        symfony: [5.4.*, 6.4.*, 7.2.*]
+        symfony: [5.4.*, 6.4.*, 7.0.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.1
-            symfony: 7.2.*
+            symfony: 7.0.*
           - php: 8.4
             symfony: 5.4.*
           - php: 8.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
         exclude:
           - php: 8.1
             symfony: 7.2.*
+          - php: 8.4
+            symfony: 5.4.*
 
     name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ubuntu-latest - ${{ matrix.dependency-version }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
             symfony: 7.2.*
           - php: 8.4
             symfony: 5.4.*
+          - php: 8.4
+            symfony: 6.4.*
 
     name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ubuntu-latest - ${{ matrix.dependency-version }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,11 @@ on: ['push', 'pull_request']
 
 jobs:
   ci:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
         php: [8.1, 8.2, 8.3, 8.4]
         symfony: [5.4.*, 6.3.*, 6.4.*, 7.0.*]
         dependency-version: [prefer-lowest, prefer-stable]
@@ -24,7 +23,7 @@ jobs:
           - php: "8.1"
             symfony: "^7.0"
 
-    name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ubuntu-latest - ${{ matrix.dependency-version }}
     steps:
 
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,9 @@ jobs:
         php: [8.1, 8.2, 8.3, 8.4]
         symfony: [5.4.*, 6.4.*, 7.2.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - php: "8.1"
-            symfony: "^5.4"
-          - php: "8.1"
-            symfony: "^6.4"
         exclude:
-          - php: "8.1"
-            symfony: "^7.2"
+          - php: 8.1
+            symfony: 7.2.*
 
     name: Tests P${{ matrix.php }} - SF${{ matrix.symfony }} - ubuntu-latest - ${{ matrix.dependency-version }}
     steps:


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

I noticed after the merge of my last PR that none of the tests ran, so I pulled the error:

> Error when evaluating 'runs-on' for job 'ci'. .github/workflows/tests.yml (Line: 7, Col: 14): Unexpected value ''

It didn't make much sense, so I tested removing the `matrix.os` and hardcoding `ubuntu-latest` which immediatly fired up the massive matrix of tests. However, the include/exclude were using caret notation while matrix using asterisk notation which caused some oddities.

I went to the [EOL website ](https://endoflife.date/symfony) and saw Symfony 6.3 was EOL, so removed it to make my life a bit easier. I then excluded any combination that failed.

This proved that PHP 8.4 isn't really working well, but I imagine thats because it needs a more modern Symfony version. I'm no Symfony dev, so I figured I'd throw this PR up to have a passing test suite and someone else could take a stab at modernizing supported versions.

(squash merge please if you go forward w/ this - a bit messy commit history)
