### PR TITLE
deps: allow openai-php/client v0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.2.0",
         "nyholm/psr7": "^1.8.2",
-        "openai-php/client": "^0.13.0",
+        "openai-php/client": "^0.14.0",
         "psr/http-client": "^1.0.3",
         "psr/http-factory": "^1.1.0",
         "symfony/config": "^5.4|^6.3|^7.1.1",


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR updates the dependency requirement for `openai-php/client` to v0.14.

Related release: https://github.com/openai-php/client/releases/tag/v0.14.0